### PR TITLE
.aliases: Add `chrome`

### DIFF
--- a/.aliases
+++ b/.aliases
@@ -56,6 +56,9 @@ alias timer='echo "Timer started. Stop with Ctrl-D." && date && time cat && date
 # Get macOS Software Updates, and update installed Ruby gems, Homebrew, npm, and their installed packages
 alias update='sudo softwareupdate -i -a; brew update; brew upgrade; brew cleanup; npm install npm -g; npm update -g; sudo gem update --system; sudo gem update; sudo gem cleanup'
 
+# Google Chrome
+alias chrome='/Applications/Google\ Chrome.app/Contents/MacOS/Google\ Chrome'
+
 # IP addresses
 alias ip="dig +short myip.opendns.com @resolver1.opendns.com"
 alias localip="ipconfig getifaddr en0"


### PR DESCRIPTION
This alias makes it easier to run Chrome with command-line flags, e.g.

    chrome --app=https://mths.be/